### PR TITLE
Added Romanian translation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 CMakeLists.txt.user
+*~

--- a/app/main.qml
+++ b/app/main.qml
@@ -159,7 +159,7 @@ MainView {
             Action {
                 id: addFriendAction
                 iconName: "add"
-                text: "Add friend"
+                text: i18n.tr("Add a friend")
 
                 onTriggered: pageStack.push(addFriendPage)
             }
@@ -197,7 +197,7 @@ MainView {
             Action {
                 id: confirmAddFriendAction
                 iconName: "ok"
-                text: i18n.tr("Add friend")
+                text: i18n.tr("Add a friend")
 
                 onTriggered: {
                     var message = (friendMessageTextField.text.length > 0) ? friendMessageTextField.text : friendMessageTextField.placeholderText

--- a/app/ui/AboutPage.qml
+++ b/app/ui/AboutPage.qml
@@ -97,7 +97,7 @@ Page {
             ListItem.Standard {
                 text: "Niklas Wenzel"
                 control: Label {
-                    text: i18n.tr("Maintainer")
+                    text: i18n.tr("Maintainer:")
                 }
             }
 

--- a/po/ro.po
+++ b/po/ro.po
@@ -1,199 +1,206 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Romanian translation (po file) for ubuntu-tox-client
+# Copyright (C) 2015 Niklas Wenzel
+# This file is distributed under the same license as the ubuntu-tox-client package.
+# Bogdan Cuza <bogdan.cuza@hotmail.com>, 2015.
 #
-#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: \n"
+"Project-Id-Version: ubuntu-tox-client\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-01-30 17:14+0200\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"POT-Creation-Date: 2015-01-21 20:39+0100\n"
+"PO-Revision-Date: 2015-01-30 17:38+0200\n"
+"Last-Translator: Bogdan Cuza <bogdan.cuza@hotmail.com>\n"
+"Language-Team: Bogdan Cuza <bogdan.cuza@hotmail.com>\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.5.4\n"
+"Language: ro\n"
 
 #: ../app/main.qml:47
+#, fuzzy
 msgid "Tox-Client"
-msgstr ""
+msgstr "Client Tox"
 
 #: ../app/main.qml:53 ../app/main.qml:155
 msgid "Contacts"
-msgstr ""
+msgstr "Contacte"
 
 #: ../app/main.qml:60
 msgid "About"
-msgstr ""
+msgstr "Despre"
 
-#: ../app/main.qml:67 ../app/main.qml:432
+#: ../app/main.qml:67 ../app/main.qml:438
 msgid "Settings"
-msgstr ""
+msgstr "Setări"
 
 #: ../app/main.qml:85
 msgid "Your Tox-ID is (click to copy):"
-msgstr ""
+msgstr "ID-ul tău Tox este (apasă pentru a copia):"
 
 #: ../app/main.qml:113
+#, fuzzy
 msgid "You are connected to the DHT"
-msgstr ""
+msgstr "Ești conectat la DHT"
 
 #: ../app/main.qml:113
+#, fuzzy
 msgid "You are <b>not</b> connected to the DHT"
-msgstr ""
+msgstr "<b>Nu</b> ești conectat la DHT"
 
 #: ../app/main.qml:124
 #, qt-format
 msgid "Incoming friend request from user %1<br>Message: %2"
-msgstr ""
+msgstr "Cerere de prietenie de la utilizatorul %1<br>Mesaj: %2"
 
 #: ../app/main.qml:134
 msgid "Accept friend request"
-msgstr ""
+msgstr "Acceptă cerere de prietenie"
 
 #: ../app/main.qml:147
 msgid "Added friend successfully! :)"
-msgstr ""
+msgstr "Prieten adăugat cu succes! :)"
 
 #: ../app/main.qml:147
 msgid "Failed to add friend! :("
-msgstr ""
+msgstr "Nu am putut să adaug pritenul! :("
 
 #: ../app/main.qml:162 ../app/main.qml:194 ../app/main.qml:200
 msgid "Add a friend"
-msgstr ""
+msgstr "Adaugă un prieten"
 
-#: ../app/main.qml:212 ../app/main.qml:453
+#: ../app/main.qml:212 ../app/main.qml:459
 msgid "Cancel"
-msgstr ""
+msgstr "Anulează"
 
 #: ../app/main.qml:228
 msgid "Tox ID:"
-msgstr ""
+msgstr "ID Tox:"
 
 #: ../app/main.qml:234
 msgid "Your friend's Tox ID"
-msgstr ""
+msgstr "ID-ul Tox al prietenului tău"
 
 #: ../app/main.qml:252
 msgid "Message:"
-msgstr ""
+msgstr "Mesaj:"
 
 #: ../app/main.qml:258
+#, fuzzy
 msgid "Let's tox!"
-msgstr ""
+msgstr "Hai să vorbim!"
 
 #: ../app/main.qml:312
 msgid "Updated nospam value"
-msgstr ""
+msgstr "Valoare nospam actualizată"
 
 #: ../app/main.qml:314
 msgid "Failed to add friend"
-msgstr ""
+msgstr "Nu am putut să adaug prietenul"
 
 #: ../app/main.qml:321
 msgid "The entered message is too long!"
-msgstr ""
+msgstr "Mesajul introdus este prea lung!"
 
 #: ../app/main.qml:323
 msgid "No message has been entered!"
-msgstr ""
+msgstr "Nici-un mesaj nu a fost introdus!"
 
 #: ../app/main.qml:325
 msgid "You cannot add yourself as a friend! ;)"
-msgstr ""
+msgstr "Nu poți să te adaugi ca prieten! ;)"
 
 #: ../app/main.qml:327
 msgid "You have already sent that user a friendship request!"
-msgstr ""
+msgstr "Deja ai trimis acea cerere de prietenie!"
 
 #: ../app/main.qml:329
 msgid "Unknown error..."
-msgstr ""
+msgstr "Eroare necunoscută..."
 
 #: ../app/main.qml:331
+#, fuzzy
 msgid "There is a checksum error in the entered Tox ID!"
-msgstr ""
+msgstr "Există o eroare de sumă de control în ID-ul Tox introdus!"
 
 #: ../app/main.qml:333
 msgid "The nospam value has been updated!"
-msgstr ""
+msgstr "Valoarea nospam a fost actualizată!"
 
 #: ../app/main.qml:335
 msgid "Increasing the friend list size has failed!"
-msgstr ""
+msgstr "Majorarea mărimii listei de prieteni a eșuat!"
 
 #: ../app/main.qml:342
 msgid "OK"
-msgstr ""
+msgstr "OK"
 
 #: ../app/main.qml:357
 msgid "Chat with "
-msgstr ""
+msgstr "Vorbește cu"
 
-#: ../app/main.qml:440
+#: ../app/main.qml:446
 msgid "Save"
-msgstr ""
+msgstr "Salvează"
 
-#: ../app/main.qml:477
+#: ../app/main.qml:483
 msgid "User name:"
-msgstr ""
+msgstr "Numele utilizatorului:"
 
-#: ../app/main.qml:500
+#: ../app/main.qml:506
+#, fuzzy
 msgid "Status message:"
-msgstr ""
+msgstr "Mesaj de statut:"
 
 #: ../app/ui/AboutPage.qml:26
 msgid "About ubuntu-tox-client"
-msgstr ""
+msgstr "Despre ubuntu-tox-client"
 
 #: ../app/ui/AboutPage.qml:61
 msgid "Info:"
-msgstr ""
+msgstr "Info:"
 
 #: ../app/ui/AboutPage.qml:65
 msgid "Version:"
-msgstr ""
+msgstr "Versiune:"
 
 #: ../app/ui/AboutPage.qml:72
 msgid "Development:"
-msgstr ""
+msgstr "Dezvoltare:"
 
 #: ../app/ui/AboutPage.qml:76
 msgid "License:"
-msgstr ""
+msgstr "Licență:"
 
 #: ../app/ui/AboutPage.qml:85
+#, fuzzy
 msgid "Source code & bug tracker:"
-msgstr ""
+msgstr "Cod sursă și urmărire de erori:"
 
 #: ../app/ui/AboutPage.qml:94
 msgid "Authors:"
-msgstr ""
+msgstr "Autori:"
 
 #: ../app/ui/AboutPage.qml:100
 msgid "Maintainer:"
-msgstr ""
+msgstr "Susținător:"
 
 #: ../app/ui/AboutPage.qml:105
 msgid "Contact:"
-msgstr ""
+msgstr "Contact:"
 
 #: ../app/ui/AboutPage.qml:115
 msgid "Uses the following libraries:"
-msgstr ""
+msgstr "Folosește următoarele biblioteci:"
 
 #: ../app/ui/AboutPage.qml:130
 msgid "ISC license"
-msgstr ""
+msgstr "Licență ISC"
 
 #: ../app/ui/AboutPage.qml:137
 msgid "Uses code from the following projects:"
-msgstr ""
+msgstr "Folosește cod din următoarele proiecte:"
 
-#: /home/boghison/Projects/toxbuild/po/ubuntu-tox-client.desktop.in.h:1
+#: /home/robbe/Programmieren/Ubuntu/build-ubuntu-tox-client-Desktop-Default/po/ubuntu-tox-client.desktop.in.h:1
 msgid "ubuntu-tox-client"
-msgstr ""
+msgstr "ubuntu-tox-client"


### PR DESCRIPTION
I am just going to leave this pull request here, please don't merge it, _yet_, I also want to add Russian translations :) *Keep in mind that there are 3 forms of you in Romanian:
- tu (you, informal)
- Dumneavoastră (you, formal)
- voi (you, plural)

and because of the general friendly style and the use of smiley faces, I used the informal you (which I am also gonna use for Russian) ;)
